### PR TITLE
Update R Roll to support gnu-only/without MKL build

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -1,2 +1,2 @@
 # Install additional system packages required for roll build.
-yum install tk-devel
+yum install tk-devel readline-devel atlas blas lapack

--- a/src/R-modules/version.mk
+++ b/src/R-modules/version.mk
@@ -9,4 +9,4 @@ VERSION_SRC = $(REDHAT.ROOT)/src/$(PACKAGE)/version.mk
 VERSION_INC = version.inc
 include $(VERSION_INC)
 
-RPM.EXTRAS  = AutoReq:No
+# RPM.EXTRAS  = AutoReq:No

--- a/src/R/Makefile
+++ b/src/R/Makefile
@@ -68,6 +68,7 @@ $(NAME).spec: DESCRIPTION LICENSE
 ifdef WITHOUT_MKL
 DESCRIBE_MKL = 
 R_CONFIG_EXTRA = --with-blas --with-lapack
+MODULE_LOAD_MKL = echo "building without mkl module"
 endif
 
 DESCRIPTION:
@@ -85,6 +86,7 @@ LICENSE: $(SRC_DIRS)
 build: $(SRC_DIRS)
 	( \
 	  $(MODULE_LOAD_CC); \
+	  $(MODULE_LOAD_MKL); \
 	  export CONFIG_OPTS="--enable-R-shlib --enable-threads=posix"; \
 	  export CONFIG_OPTS="$${CONFIG_OPTS} $(R_CONFIG_EXTRA)"; \
 	  if test -n "$${MKL_ROOT}"; then \

--- a/src/R/Makefile
+++ b/src/R/Makefile
@@ -64,6 +64,12 @@ include $(SDSCDEVEL)/Rules.mk
 
 $(NAME).spec: DESCRIPTION LICENSE
 
+## If building without MKL, add blas and lapack
+ifdef WITHOUT_MKL
+DESCRIBE_MKL = 
+R_CONFIG_EXTRA = --with-blas --with-lapack
+endif
+
 DESCRIPTION:
 	$(MODULE_LOAD_CC); \
 	( \
@@ -79,8 +85,8 @@ LICENSE: $(SRC_DIRS)
 build: $(SRC_DIRS)
 	( \
 	  $(MODULE_LOAD_CC); \
-	  $(MODULE_LOAD_MKL); \
 	  export CONFIG_OPTS="--enable-R-shlib --enable-threads=posix"; \
+	  export CONFIG_OPTS="$${CONFIG_OPTS} $(R_CONFIG_EXTRA)"; \
 	  if test -n "$${MKL_ROOT}"; then \
 	    export MKLLIB=`find $${MKL_ROOT}/lib/* -maxdepth 0 | head -1`; \
 	    export MKLLINK="-L$${MKLLIB} -lmkl_rt"; \

--- a/src/R/version.mk
+++ b/src/R/version.mk
@@ -1,5 +1,6 @@
 ifndef ROLLCOMPILER
   ROLLCOMPILER = gnu
+  WITHOUT_MKL = true
 endif
 COMPILERNAME := $(firstword $(subst /, ,$(ROLLCOMPILER)))
 
@@ -18,4 +19,4 @@ SOURCE_DIR     = $(SOURCE_PKG:%.$(SOURCE_SUFFIX)=%)
 
 TAR_GZ_PKGS    = $(SOURCE_PKG)
 
-RPM.EXTRAS     = AutoReq:No
+# RPM.EXTRAS     = AutoReq:No


### PR DESCRIPTION
Trying to make this roll more "generic" so that the base case does not require MKL.
Should not affect builds in which a compiler or compilers is/are specified. 
